### PR TITLE
Back compatibility with 1.0.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,4 @@
-resource "commercetools_api_client" "unprotected" {
+resource "commercetools_api_client" "api_client" {
   count = var.api_client.protected ? 0 : 1
   name  = var.api_client.name
   scope = var.api_client.scope

--- a/output.tf
+++ b/output.tf
@@ -3,6 +3,6 @@ output "api_client" {
   value = element(coalescelist(
     commercetools_api_client.protected,
     commercetools_api_client.api_client,
-), 0)
+  ), 0)
   sensitive = true
 }

--- a/output.tf
+++ b/output.tf
@@ -2,7 +2,7 @@ output "api_client" {
   description = "created api client through terraform"
   value = element(coalescelist(
     commercetools_api_client.protected,
-    commercetools_api_client.unprotected,
-  ), 0)
+    commercetools_api_client.api_client,
+), 0)
   sensitive = true
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+terraform {
+  required_version = ">= 0.12"
+}
+


### PR DESCRIPTION
In order to avoid of credential rotation while moving from version `1.0.0` we have to keep resource names.