### PR TITLE
OPS-5753 Re-use project key in resource creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Type:
 ```hcl
 map(object({
     name  = string,
-    scope = list(string)
+    scope = set(string)
   }))
 ```
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  client_id     = var.client_id_ssm_path != "" ? join("", data.aws_ssm_parameter.client_id.*.value) : var.client_id
+  client_secret = var.client_secret_ssm_path != "" ? join("", data.aws_ssm_parameter.client_secret.*.value) : var.client_secret
+  client_scopes = var.client_scopes_ssm_path != "" ? join("", data.aws_ssm_parameter.client_scopes.*.value) : var.client_scopes # "manage_project:my-project"
+  project_key   = var.project_key_ssm_path != "" ? join("", data.aws_ssm_parameter.project_key.*.value) : var.project_key       # "my-project"
+  api_url       = var.api_url_ssm_path != "" ? join("", data.aws_ssm_parameter.api_url.*.value) : var.api_url                   # "https://api.europe-west1.gcp.commercetools.com/"
+  token_url     = var.token_url_ssm_path != "" ? join("", data.aws_ssm_parameter.token_url.*.value) : var.token_url             # "https://auth.europe-west1.gcp.commercetools.com/"
+}

--- a/main.tf
+++ b/main.tf
@@ -6,5 +6,5 @@ moved {
 resource "commercetools_api_client" "this" {
   for_each = var.api_clients
   name     = each.value.name
-  scope    = each.value.scope
+  scope    = [for s in each.value.scope : join(":", [s, local.project_key])]
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,8 +1,8 @@
 provider "commercetools" {
-  client_id     = var.client_id_ssm_path != "" ? join("", data.aws_ssm_parameter.client_id.*.value) : var.client_id
-  client_secret = var.client_secret_ssm_path != "" ? join("", data.aws_ssm_parameter.client_secret.*.value) : var.client_secret
-  scopes        = var.client_scopes_ssm_path != "" ? join("", data.aws_ssm_parameter.client_scopes.*.value) : var.client_scopes # "manage_project:flaconi-dev"
-  project_key   = var.project_key_ssm_path != "" ? join("", data.aws_ssm_parameter.project_key.*.value) : var.project_key
-  api_url       = var.api_url_ssm_path != "" ? join("", data.aws_ssm_parameter.api_url.*.value) : var.api_url       # "https://api.europe-west1.gcp.commercetools.com/"
-  token_url     = var.token_url_ssm_path != "" ? join("", data.aws_ssm_parameter.token_url.*.value) : var.token_url # "https://auth.europe-west1.gcp.commercetools.com/"
+  client_id     = local.client_id
+  client_secret = local.client_secret
+  scopes        = local.client_scopes
+  project_key   = local.project_key
+  api_url       = local.api_url
+  token_url     = local.token_url
 }

--- a/variables.tf
+++ b/variables.tf
@@ -73,7 +73,7 @@ variable "token_url_ssm_path" {
 variable "api_clients" {
   type = map(object({
     name  = string,
-    scope = list(string)
+    scope = set(string)
   }))
   default     = {}
   description = "Map of API clients"


### PR DESCRIPTION
Use project key from provider as it the same everywhere anyway.